### PR TITLE
set mode for config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,8 @@ module.exports = function (cb) {
         
         exists(file, function (ex) {
             if (!ex) prompt(function (vars) {
-                fs.writeFile(file, JSON.stringify(vars), function (err) {
+                var options = {mode: 0700 & (~process.umask())};
+                fs.writeFile(file, JSON.stringify(vars), options, function (err) {
                     if (err) console.error(err)
                     else read()
                 });


### PR DESCRIPTION
Because this stores the user's GitHub password in plain text in the config file, and because some users have unfortunate permissive umasks and/or may not realize that their password is being stored, create the config file with a restrictive mode.
