### PR TITLE
Use SVG and show status of master branch

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -32,7 +32,7 @@ withConfig(function (config) {
         else if (process.argv[2] === 'badge') {
             console.log([
                 '[![build status](https://secure.travis-ci.org/',
-                repo, '.png)]',
+                repo, '.svg?branch=master)]',
                 '(http://travis-ci.org/', repo, ')',
             ].join(''));
         }


### PR DESCRIPTION
Show the build status of the master branch instead of the default behavior, which shows the build status of the latest build on any branch. See http://docs.travis-ci.com/user/status-images/.

Use svg for better font rendering.