### PR TITLE
Install npm@2 instead of npm@~1.4.6

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -59,7 +59,7 @@ withConfig(function (config) {
                             return '  - "' + v.replace(/\.\d+$/, '') + '"';
                         }).join('\n'),
                         'before_install:',
-                        '  - npm install -g npm@~1.4.6'
+                        '  - npm install -g npm@2'
                     ].join('\n') + '\n');
                     
                     console.log('# created a .travis.yml');


### PR DESCRIPTION
npm 1.4.x is pretty old now and installing npm@2 instead of a specific minor version will allow catching breaking npm changes earlier.